### PR TITLE
added permission to DELETE DBClusterSnapshots.

### DIFF
--- a/infrastructure/templates/rds-cross-region-backup.json
+++ b/infrastructure/templates/rds-cross-region-backup.json
@@ -238,6 +238,7 @@
                                         "rds:DescribeDbSnapshots",
                                         "rds:CopyDbSnapshot",
                                         "rds:DeleteDbSnapshot",
+                                        "rds:DeleteDbClusterSnapshot",
                                         "rds:DescribeDbClusters",
                                         "rds:DescribeDbClusterSnapshots",
                                         "rds:CopyDBClusterSnapshot"


### PR DESCRIPTION
Without this permission, the lambda starts failing after the first of several DBClusters, because of not being able to purge older snapshots for the first DBCluster.